### PR TITLE
Fix #21

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -673,7 +673,11 @@ export class Converter {
                 // Use void as return type if there were no parameters
                 // Note that the join is kinda useless (see long comments above)
                 let promiseReturn = parameters[0] || 'void';
-                if (callback.optional && !ALREADY_OPTIONAL_RETURNS.includes(promiseReturn)) promiseReturn += ' | undefined';
+
+                // https://github.com/jsmnbom/definitelytyped-firefox-webext-browser/issues/21
+                //if (callback.optional && !ALREADY_OPTIONAL_RETURNS.includes(promiseReturn)) promiseReturn += ' |
+                // undefined';
+
                 returnType = `Promise<${promiseReturn}>`;
                 // Because of namespace extends(?), a few functions can pass through here twice,
                 // so override the return type since the callback was removed and it can't be converted again

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -647,6 +647,13 @@ export class Converter {
         let returnType: string | TypeSchema = 'void';
         // Prove otherwise? either a normal returns or as an async promise
         if (func.returns) {
+            // First check if it has a callbackc and a return value
+            // If it does it's probably cause we overwrote the return value in index.ts and we need to remove the
+            // callback parameter anyways
+            let callback = func.parameters && func.parameters.find(x => x.type === 'function' && x.name === func.async);
+            if (callback) {
+                func.parameters = func.parameters!.filter(x => x !== callback);
+            }
             returnType = this.convertType(func.returns);
             if (func.returns.optional && !ALREADY_OPTIONAL_RETURNS.includes(returnType)) returnType += ' | void';
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,11 +217,6 @@ converter.edit('events', 'types', 'Event', x => {
     }
     return x;
 });
-// This should prob also not return promise
-converter.edit('devtools.panels', 'types', 'ElementsPanel', x => {
-    x.functions[0].async = false;
-    return x;
-});
 // Remove bookmarks.import and bookmarks.export as it breaks things
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24937
 converter.remove('bookmarks', 'functions', 'import');


### PR DESCRIPTION
This should fix #21 by removing |undefined from promise returns unless it needs to be there (sessions.getTabValue and sessions.getWindowValue).

Also removes the rest of the callback parameters from functions that still had them even tho the function actually returns a Promise.