### PR TITLE
Fix converting array of a union type

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -553,7 +553,8 @@ export default class Converter {
             arrayType.includes('\n') ||
             arrayType.includes(';') ||
             arrayType.includes(',') ||
-            arrayType.includes('"')
+            arrayType.includes('"') ||
+            arrayType.includes('|')
           ) {
             // If it's not simple, use the Array<type> syntax
             out += `Array<${arrayType}>`;


### PR DESCRIPTION
The following property, defined in the browser.menus schema, represents an array of either integers or strings:

    "menuIds": {
      "description": "A list of IDs of the menu items that were shown.",
      "type": "array",
      "items": {
        "choices": [
          { "type": "integer" },
          { "type": "string" }
        ]
      }
    }

This commit changes the generated type from:

    interface _OnShownInfo {
        /** A list of IDs of the menu items that were shown. */
        menuIds: number | string[];
        ...
    }

to:

    interface _OnShownInfo {
        /** A list of IDs of the menu items that were shown. */
        menuIds: Array<number | string>;
        ...
    }